### PR TITLE
Remove erronous end tag

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -54,7 +54,7 @@ class Collection {
       /// @todo Fetch and minify proprietary styles.
 
       $tags .= '<link rel="stylesheet" type="text/css" '
-        . 'href="' . htmlspecialchars($style) . '"></link>' . "\n";
+        . 'href="' . htmlspecialchars($style) . '">' . "\n";
     }
     return $tags;
   }


### PR DESCRIPTION
The <link> element does not have an end tag.
