### PR TITLE
Proper ordering of dependecies

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -59,15 +59,32 @@ class Collection {
     return $tags;
   }
 
+  /**
+   * Return an ordered array of all components. Dependencies up front before their dependees.
+   */
   public function getAllComponents() {
     $all_components = array();
 
     foreach ($this->components as $component) {
-      $all_components = array_merge($all_components, $component->getDependencies());
       $all_components[$component->name] = $component;
+      $all_components = array_merge($all_components, $component->getDependencies());
     }
 
-    return $all_components;
+    // First we reverse the list to get the correct dependency oredering, i.e. deps upfront
+    $all_components = array_reverse($all_components);
+
+    // Then we need to remove duplicate components, while keeping order.
+    $lookup = array();
+    $filtered = array();
+
+    foreach ($all_components as $component) {
+      if (!isset($lookup[$component->name])) {
+        $lookup[$component->name] = true;
+        $filtered[] = $component;
+      }
+    }
+
+    return $filtered;
   }
 
   public function needsAngular() {

--- a/lib/Component.php
+++ b/lib/Component.php
@@ -34,6 +34,11 @@ class Component {
     }
   }
 
+  /**
+   * Get all the dependencies of a component, and their dependencies, in an ordered array.
+   * Duplicates may occur when two different dependencies in
+   * turn depends on the same component.
+   */
   public function getDependencies() {
     $dependencies = array();
 
@@ -42,7 +47,7 @@ class Component {
     foreach ($this->spec->dependencies as $name => $spec) {
       // Assume $spec is a version.
       $component = $this->factory->get($name, $spec);
-      $dependencies[$name] = $component;
+      $dependencies[] = $component;
 
       // Add the dependent components dependencies.
       $dependencies = array_merge($dependencies, $component->getDependencies());

--- a/test/unit/ComponentTest.php
+++ b/test/unit/ComponentTest.php
@@ -19,7 +19,7 @@ class ComponentTest extends PHPUnit_Framework_TestCase {
     $component = self::$factory->get('test_3');
     $dependencies = $component->getDependencies();
 
-    $this->assertEquals('test_1', $dependencies['test_1']->name);
+    $this->assertEquals('test_1', $dependencies[0]->name);
   }
 
   public function testGetStyles() {


### PR DESCRIPTION
...so script and style tags render in proper order.

This is done by traversing the dependencies bottom first and then remove the duplicates. 